### PR TITLE
增加树莓派支持

### DIFF
--- a/Dockerfile.raspberrypi
+++ b/Dockerfile.raspberrypi
@@ -1,0 +1,21 @@
+FROM arm32v7/python:3.6-slim-stretch
+
+MAINTAINER <pjialin admin@pjialin.com>
+ENV TZ Asia/Shanghai
+
+WORKDIR /code
+
+COPY ./sources.list /etc/apt/
+RUN apt-get update && apt-get install -y --allow-unauthenticated gcc libxml2-dev libxslt-dev libz-dev python-dev
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+RUN mkdir -p /data/query /data/user
+VOLUME /data
+
+COPY . .
+
+COPY env.docker.py.example /config/env.py
+
+CMD [ "python", "main.py" , "-c", "/config/env.py"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ cp docker-compose.yml.example docker-compose.yml
 ```
 docker-compose up -d
 ```
+### Raspberry Pi 中使用
+已在Raspberry Pi 3B+ 、Raspbian Stretch中测试。
+**1.Dockerfile**
+下载repo后，使用Dockerfile.raspberrypi替换Dockerfile
+```
+cd py12306
+rm Dockerfile
+mv Dockerfile.raspberrypi Dockerfile
+```
+**2.build image**
+限于树莓派的性能，build过程有些慢，特别是build lxml部分。需要耐心等待。
+```
+docker build -t py12306:latest .
+```
+build成功后，运行部分与前文一致。
 
 ## Web 管理页面
 

--- a/README.md
+++ b/README.md
@@ -115,19 +115,32 @@ docker-compose up -d
 ```
 ### Raspberry Pi 中使用
 已在Raspberry Pi 3B (Raspbian Stretch)中测试。
-**1.Dockerfile**
-下载repo后，使用Dockerfile.raspberrypi替换Dockerfile
+**1.下载源码**
+```
+git clone https://github.com/pjialin/py12306.git
+```
+**2.Dockerfile**
+用Dockerfile.raspberrypi替换Dockerfile
 ```
 cd py12306
 rm Dockerfile
 mv Dockerfile.raspberrypi Dockerfile
 ```
-**2.build image**
+**3.build image**
 限于树莓派的性能，build过程有些慢，特别是build lxml部分，需要耐心等待
 ```
 docker build -t py12306:latest .
 ```
-build成功后，运行部分与前文一致
+**4.抢票配置**
+根据自己需要，修改env.docker.py.example后
+```
+cp env.docker.py.example env.py
+```
+**4.运行**
+由于步骤3设置的image名为py12306，运行时，注意该名称。
+```
+docker run --rm --name py12306 -p 8008:8008 -d -v $(pwd):/config -v py12306:/data py12306
+```
 
 ## Web 管理页面
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cp docker-compose.yml.example docker-compose.yml
 docker-compose up -d
 ```
 ### Raspberry Pi 中使用
-已在Raspberry Pi 3B+ 、Raspbian Stretch中测试。
+已在Raspberry Pi 3B (Raspbian Stretch)中测试。
 **1.Dockerfile**
 下载repo后，使用Dockerfile.raspberrypi替换Dockerfile
 ```
@@ -123,11 +123,11 @@ rm Dockerfile
 mv Dockerfile.raspberrypi Dockerfile
 ```
 **2.build image**
-限于树莓派的性能，build过程有些慢，特别是build lxml部分。需要耐心等待。
+限于树莓派的性能，build过程有些慢，特别是build lxml部分，需要耐心等待
 ```
 docker build -t py12306:latest .
 ```
-build成功后，运行部分与前文一致。
+build成功后，运行部分与前文一致
 
 ## Web 管理页面
 

--- a/sources.list
+++ b/sources.list
@@ -1,0 +1,2 @@
+deb http://mirrors.tuna.tsinghua.edu.cn/raspbian/raspbian/ stretch main non-free contrib
+deb-src http://mirrors.tuna.tsinghua.edu.cn/raspbian/raspbian/ stretch main non-free contrib

--- a/sources.list
+++ b/sources.list
@@ -1,2 +1,3 @@
 deb http://mirrors.tuna.tsinghua.edu.cn/raspbian/raspbian/ stretch main non-free contrib
 deb-src http://mirrors.tuna.tsinghua.edu.cn/raspbian/raspbian/ stretch main non-free contrib
+#根据你的网络情况选择镜像站点，根据你的树莓派系统版本配置。


### PR DESCRIPTION
增加支持用于在树莓派上build image、运行
1.增加Dockerfile.raspberrypi，用于在树莓派（arm32v7）上build image，主要变更了base image、使用APT安装部分依赖，其余未作变更
2.增加sources.list，以TUNA的 Raspbian Stretch为例
已在Raspberry Pi 3B（Raspbian Stretch）上测试成功。