### PR TITLE
修复邮件通知

### DIFF
--- a/py12306/helpers/notification.py
+++ b/py12306/helpers/notification.py
@@ -125,9 +125,9 @@ class Notification():
         message.set_content(content)
         try:
             server = smtplib.SMTP(Config().EMAIL_SERVER_HOST)
-            server.login(Config().EMAIL_SERVER_USER, Config().EMAIL_SERVER_PASSWORD)
             server.ehlo()
             server.starttls()
+            server.login(Config().EMAIL_SERVER_USER, Config().EMAIL_SERVER_PASSWORD)
             server.send_message(message)
             server.quit()
             CommonLog.add_quick_log(CommonLog.MESSAGE_SEND_EMAIL_SUCCESS).flush()


### PR DESCRIPTION
创建了安全连接后需要重新认证