### PR TITLE
[szhang01/fix_env_overwrite] Comment out unnecessary setting in env.py.example

### DIFF
--- a/env.py.example
+++ b/env.py.example
@@ -77,7 +77,9 @@ BARK_ENABLED = 0
 BARK_PUSH_URL = 'https://api.day.app/:your_token'
 
 # 输出日志到文件
-OUT_PUT_LOG_TO_FILE_ENABLED = 0
+# 默认设置不需要，related issue: https://github.com/pjialin/py12306/issues/319
+# 如需更改再 uncomment 掉下面这行
+# OUT_PUT_LOG_TO_FILE_ENABLED = 0
 OUT_PUT_LOG_TO_FILE_PATH = 'runtime/12306.log'  # 日志目录
 
 # 分布式集群配置


### PR DESCRIPTION
### Reviewers
@pjialin 

### What this PR does:
This pr is used to solve the overwrite issue reported here: https://github.com/pjialin/py12306/issues/319
in order to not overwrite the value already sets in Config, we should comment out the variable in env.py.example.
The overwrite process is here: https://github.com/pjialin/py12306/blob/master/py12306/config.py#L173
when people specify `-o env.py` option in command line.

### Tests:
No tests.