### PR TITLE
fix(sec): upgrade lxml to 4.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-JWT-Extended==3.15.0
 idna==2.8
 itsdangerous==1.1.0
 Jinja2==2.10
-lxml==4.6.3
+lxml==4.9.1
 MarkupSafe==1.1.0
 parse==1.9.0
 pyee==5.0.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in lxml 4.6.3
- [CVE-2022-2309](https://www.oscs1024.com/hd/CVE-2022-2309)


### What did I do？
Upgrade lxml from 4.6.3 to 4.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>