### PR TITLE
fix(sec): upgrade websockets to 10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ soupsieve==1.6.2
 tqdm==4.28.1
 urllib3==1.24.2
 w3lib==1.19.0
-websockets==7.0
+websockets==10.0
 Werkzeug==0.15.5
 DingtalkChatbot==1.3.0
 lightpush==0.1.3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in websockets 7.0
- [MPS-2022-15208](https://www.oscs1024.com/hd/MPS-2022-15208)


### What did I do？
Upgrade websockets from 7.0 to 10.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS