### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ requests-html==0.9.0
 six==1.12.0
 soupsieve==1.6.2
 tqdm==4.28.1
-urllib3==1.24.2
+urllib3==1.26.5
 w3lib==1.19.0
 websockets==7.0
 Werkzeug==0.15.5


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.24.2
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.24.2 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS